### PR TITLE
:art: Fix aligment

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container-fluid">
             <div class="navbar-nav w-100 justify-content-between nav-fill">
-                <button type="button" class="btn" onclick="toggleLight()" id="toggleLight"></button>
+                <div type="button" class="h2" onclick="toggleLight()" id="toggleLight"></div>
                 <div class="col text-center">
                     <p data-i18n-key="title" id="title" class="h2">AI Tetris</p>
                 </div>
@@ -30,7 +30,6 @@
                         <option value="nl">Nederlands</option>
                     </select>
                 </div>
-
             </div>
         </div>
     </nav>

--- a/tetris.css
+++ b/tetris.css
@@ -1,3 +1,11 @@
+body, html {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+}
+
 p {
     margin: 0px;
     padding: 5px;


### PR DESCRIPTION
A little bit of a hacky way, but the way it was structured with bootstrap before meant that the button and title had different paddings and margins, and couldn't be easily aligned using own css while keeping things tidy.
This was changed by just changing the button to an `h2` class and leaving the `type="button"` for cursor behavior.

Closes #2 